### PR TITLE
Fix retried tasks with expirations (#3734)

### DIFF
--- a/celery/app/amqp.py
+++ b/celery/app/amqp.py
@@ -331,7 +331,9 @@ class AMQP(object):
                 now + timedelta(seconds=expires), tz=timezone,
             )
         eta = eta and eta.isoformat()
-        expires = expires and expires.isoformat()
+        # If we retry a task `expires` will already be ISO8601-formatted.
+        if not isinstance(expires, basestring):
+            expires = expires and expires.isoformat()
 
         if argsrepr is None:
             argsrepr = saferepr(args, self.argsrepr_maxsize)

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -55,3 +55,11 @@ def collect_ids(self, res, i):
 
     """
     return res, (self.request.root_id, self.request.parent_id, i)
+
+
+@shared_task(bind=True, expires=60.0, max_retries=1)
+def retry_once(self):
+    """Task that fails and is retried. Returns the number of retries."""
+    if self.request.retries:
+        return self.request.retries
+    raise self.retry(countdown=0.1)

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 from celery import group
 from .conftest import flaky
-from .tasks import print_unicode, sleeping
+from .tasks import print_unicode, retry_once, sleeping
 
 
 class test_tasks:
@@ -11,6 +11,11 @@ class test_tasks:
         r1 = sleeping.delay(sleep)
         sleeping.delay(sleep)
         manager.assert_accepted([r1.id])
+
+    @flaky
+    def test_task_retried(self):
+        res = retry_once.delay()
+        assert res.get(timeout=10) == 1  # retried once
 
     @flaky
     def test_unicode_task(self, manager):


### PR DESCRIPTION
Fixes #3734 (tasks could not be retried if `expires` is set.)

I spent a awhile trying to find the right place to add a call to `maybe_iso8601`, but eventually gave up and added a special case to amqp.py; there are already several functions that assume `expires` is ISO8601-formatted, and it didn't seem that worthwhile to add that assumption to another one.

I'm unsure whether it makes sense to document the fact that `expires` can now be an ISO8601 timestamp and add unit tests for that case, so for now I've stuck in an integration test to make sure that retries actually get run. Let me know if this seems wrong and I'd be happy to change it.